### PR TITLE
csv valid types for windows

### DIFF
--- a/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImportStep1.component.js
+++ b/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImportStep1.component.js
@@ -41,11 +41,17 @@ function organizationContactImportStep1Controller($scope) {
                     const file = input.files[0];
                     this.fileName = file.name;
 
-                    if (file.type === 'text/csv') {
+                    if (
+                        _.includes(
+                            ['text/csv', 'application/vnd.ms-excel'],
+                            file.type,
+                        )
+                    ) {
                         this.parseCsv(file);
                     } else {
                         this.fileTypeError = true;
                         delete this.csvData;
+                        delete this.fileName;
                     }
                 });
             },


### PR DESCRIPTION
Windows machines with Excel installed return a different type for the file.  This allows them to continue.