### PR TITLE
MHP-2333: Hide validate phone number feature unless org is typeform_e…

### DIFF
--- a/app/assets/javascripts/angular/components/surveyOverviewSettingsTab/surveyOverviewSettings.html
+++ b/app/assets/javascripts/angular/components/surveyOverviewSettingsTab/surveyOverviewSettings.html
@@ -61,64 +61,69 @@
                         {{'surveys:settings.image_delete' | t}}
                     </button>
                 </div>
-                <div class="mt4 bb pb4 b--pivot-gray tl">
-                    <input
-                        type="checkbox"
-                        id="validatePhoneNumber"
-                        placeholder="{{'surveys:settings.validation_message' | t}}"
-                        ng-model="$ctrl.surveyEdit.validate_phone_number"
-                        ng-change="$ctrl.saveSurvey()"
-                        ng-disabled="!$ctrl.directAdminPrivileges">
-                    <label class="fw6 f5 bold ml2 mb0 blue ttu tracked" for="validatePhoneNumber">
-                        {{'surveys:settings.validate_phone_number' | t}}
-                    </label>
-                    <p class="f7 pivot-gray-darker mt2 mb0 lh-16">
-                        {{'surveys:settings.validate_phone_number_hint' | t}}
-                    </p>
-                </div>
-                <div class="mt4 bb pb4 b--pivot-gray tl" ng-if="$ctrl.surveyEdit.validate_phone_number">
-                    <label class="db fw6 lh-copy f5 bold mb1 blue ttu tracked" for="validationMessage">
-                        {{'surveys:settings.validation_message' | t}}
-                    </label>
-                    <p class="f7 pivot-gray-darker mt0 lh-16">
-                        {{'surveys:settings.validation_message_hint' | t}}
-                        <a class="help fr" href="" ng-click="$ctrl.showValidationMessageHelp = !$ctrl.showValidationMessageHelp">
-                            <img alt="{{'common:general.help' | t}}" ng-src="{{$ctrl.helpIcon}}" style="width:16px; height:16px;">
-                        </a>
-                    </p>
-                    <div class="help-text" ng-if="$ctrl.showValidationMessageHelp">
-                        <p class="pivot-gray-darker f7 lh-copy pv2">
-                            {{'surveys:settings.validation_message_help' | t}}
+                <div ng-if="$ctrl.survey.organization.typeform_enabled">
+                    <div class="mt4 bb pb4 b--pivot-gray tl">
+                        <input
+                            type="checkbox"
+                            id="validatePhoneNumber"
+                            placeholder="{{'surveys:settings.validation_message' | t}}"
+                            ng-model="$ctrl.surveyEdit.validate_phone_number"
+                            ng-change="$ctrl.saveSurvey()"
+                            ng-disabled="!$ctrl.directAdminPrivileges">
+                        <label class="fw6 f5 bold ml2 mb0 blue ttu tracked" for="validatePhoneNumber">
+                            {{'surveys:settings.validate_phone_number' | t}}
+                        </label>
+                        <p class="f7 pivot-gray-darker mt2 mb0 lh-16">
+                            {{'surveys:settings.validate_phone_number_hint' | t}}
                         </p>
                     </div>
-                    <textarea
-                        class="pa2 input-reset bg-white bw0 pivot-gray-darker w-100"
-                        id="validationMessage"
-                        maxlength="110"
-                        placeholder="{{'surveys:settings.validation_message' | t}}"
-                        ng-model="$ctrl.surveyEdit.validation_message"
-                        ng-change="$ctrl.saveSurvey()"
-                        ng-readonly="!$ctrl.directAdminPrivileges">
+                    <div class="mt4 bb pb4 b--pivot-gray tl" ng-if="$ctrl.surveyEdit.validate_phone_number">
+                        <label class="db fw6 lh-copy f5 bold mb1 blue ttu tracked" for="validationMessage">
+                            {{'surveys:settings.validation_message' | t}}
+                        </label>
+                        <p class="f7 pivot-gray-darker mt0 lh-16">
+                            {{'surveys:settings.validation_message_hint' | t}}
+                            <a class="help fr" href=""
+                               ng-click="$ctrl.showValidationMessageHelp = !$ctrl.showValidationMessageHelp">
+                                <img alt="{{'common:general.help' | t}}" ng-src="{{$ctrl.helpIcon}}"
+                                     style="width:16px; height:16px;">
+                            </a>
+                        </p>
+                        <div class="help-text" ng-if="$ctrl.showValidationMessageHelp">
+                            <p class="pivot-gray-darker f7 lh-copy pv2">
+                                {{'surveys:settings.validation_message_help' | t}}
+                            </p>
+                        </div>
+                        <textarea
+                            class="pa2 input-reset bg-white bw0 pivot-gray-darker w-100"
+                            id="validationMessage"
+                            maxlength="110"
+                            placeholder="{{'surveys:settings.validation_message' | t}}"
+                            ng-model="$ctrl.surveyEdit.validation_message"
+                            ng-change="$ctrl.saveSurvey()"
+                            ng-readonly="!$ctrl.directAdminPrivileges">
                     </textarea>
-                    <p class="f7 pivot-gray-darker mt2 lh-16">
-                        {{ 'messages.length_limit' | t : { remaining_characters: 110 - $ctrl.surveyEdit.validation_message.length } }}
-                    </p>
-                </div>
-                <div class="mt4 bb pb4 b--pivot-gray tl" ng-if="$ctrl.surveyEdit.validate_phone_number">
-                    <label class="db fw6 lh-copy f5 bold mb1 blue ttu tracked" for="validationSuccessMessage">
-                        {{'surveys:settings.validation_success_message' | t}}
-                    </label>
-                    <p class="f7 pivot-gray-darker mt0 lh-16">
-                        {{'surveys:settings.validation_success_message_hint' | t}}
-                    </p>
-                    <textarea
-                        class="pa2 input-reset bg-white bw0 pivot-gray-darker w-100"
-                        id="validationSuccessMessage"
-                        placeholder="{{'surveys:settings.validation_success_message' | t}}"
-                        ng-model="$ctrl.surveyEdit.validation_success_message"
-                        ng-change="$ctrl.saveSurvey()"
-                        ng-readonly="!$ctrl.directAdminPrivileges">
+                        <p class="f7 pivot-gray-darker mt2 lh-16">
+                            {{ 'messages.length_limit' | t : { remaining_characters: 110 -
+                            $ctrl.surveyEdit.validation_message.length } }}
+                        </p>
+                    </div>
+                    <div class="mt4 bb pb4 b--pivot-gray tl" ng-if="$ctrl.surveyEdit.validate_phone_number">
+                        <label class="db fw6 lh-copy f5 bold mb1 blue ttu tracked" for="validationSuccessMessage">
+                            {{'surveys:settings.validation_success_message' | t}}
+                        </label>
+                        <p class="f7 pivot-gray-darker mt0 lh-16">
+                            {{'surveys:settings.validation_success_message_hint' | t}}
+                        </p>
+                        <textarea
+                            class="pa2 input-reset bg-white bw0 pivot-gray-darker w-100"
+                            id="validationSuccessMessage"
+                            placeholder="{{'surveys:settings.validation_success_message' | t}}"
+                            ng-model="$ctrl.surveyEdit.validation_success_message"
+                            ng-change="$ctrl.saveSurvey()"
+                            ng-readonly="!$ctrl.directAdminPrivileges">
                     </textarea>
+                    </div>
                 </div>
             </fieldset>
         </form>


### PR DESCRIPTION
…nabled

https://jira.cru.org/browse/MHP-2333

I'm a little confused about why this is needed. How do orgs become `typeform_enabled`? Is that something orgs can opt into? I thought they could just click the [add typeform button](https://github.com/CruGlobal/missionhub-web/pull/93/files#diff-add512720605f878ca581d5fe9738810R14) but I see now there's a check there too. Is that flag something that got manually turned on in the DB for NZ orgs?

Is there a reason to restrict these features to NZ? Seems like the fewer special case feature sets we add the better. Are there plans to roll it out globally? I never heard the motivation for adding phone validation. Typeform seems like it would be useful for everyone.

Reviewing this with whitespace off should be easier. Since Prettier doesn't format HTML files 😢 I just reformatted the whole file with Intellij.