### PR TITLE
Remove manifest.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,52 +2,52 @@ sudo: false
 language: node_js
 node_js: '8'
 addons:
-  chrome: stable
+    chrome: stable
 
 script:
-  - yarn test
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && ([ "$TRAVIS_BRANCH" == "master" ]
+    - yarn test
+    - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && ([ "$TRAVIS_BRANCH" == "master" ]
       || [ "$TRAVIS_BRANCH" == "staging" ]); then
-        yarn run onesky:download;
-        yarn run build;
-    fi
+      yarn run onesky:download;
+      yarn run build;
+      fi
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+    - bash <(curl -s https://codecov.io/bash)
+    - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
       yarn run onesky:upload;
-    fi
+      fi
 
 cache:
-  yarn: true
-  directories:
-  - node_modules
+    yarn: true
+    directories:
+        - node_modules
 
 before_deploy:
-  - pip install --user awscli
+    - pip install --user awscli
 
 deploy:
-- provider: script
-  script: ~/.local/bin/aws s3 sync dist s3://cru-missionhub-web-stage --region us-east-1 --acl public-read --exclude '*.html' --exclude 'manifest.json' --cache-control 'public, max-age=31536000' --delete
-  skip_cleanup: true
-  on:
-    branch: staging
-- provider: script
-  script: ~/.local/bin/aws s3 sync dist s3://cru-missionhub-web-stage --region us-east-1 --acl public-read --include '*.html' --include 'manifest.json' --cache-control 'public, no-cache' --delete
-  skip_cleanup: true
-  on:
-    branch: staging
-- provider: script
-  script: ~/.local/bin/aws s3 sync dist s3://cru-missionhub-web-prod --region us-east-1 --acl public-read --exclude '*.html' --exclude 'manifest.json' --cache-control 'public, max-age=31536000'
-  skip_cleanup: true
-  on:
-    branch: master
-- provider: script
-  script: ~/.local/bin/aws s3 sync dist s3://cru-missionhub-web-prod --region us-east-1 --acl public-read --include '*.html' --include 'manifest.json' --cache-control 'public, max-age=180'
-  skip_cleanup: true
-  on:
-    branch: master
+    - provider: script
+      script: ~/.local/bin/aws s3 sync dist s3://cru-missionhub-web-stage --region us-east-1 --acl public-read --exclude '*.html' --exclude 'manifest.json' --cache-control 'public, max-age=31536000' --delete
+      skip_cleanup: true
+      on:
+          branch: staging
+    - provider: script
+      script: ~/.local/bin/aws s3 sync dist s3://cru-missionhub-web-stage --region us-east-1 --acl public-read --include '*.html' --cache-control 'public, no-cache' --delete
+      skip_cleanup: true
+      on:
+          branch: staging
+    - provider: script
+      script: ~/.local/bin/aws s3 sync dist s3://cru-missionhub-web-prod --region us-east-1 --acl public-read --exclude '*.html' --exclude 'manifest.json' --cache-control 'public, max-age=31536000'
+      skip_cleanup: true
+      on:
+          branch: master
+    - provider: script
+      script: ~/.local/bin/aws s3 sync dist s3://cru-missionhub-web-prod --region us-east-1 --acl public-read --include '*.html' --cache-control 'public, max-age=180'
+      skip_cleanup: true
+      on:
+          branch: master
 env:
-  global:
-  - AWS_ACCESS_KEY_ID=AKIAIELROGTP3V2UJKRA
-  - secure: ExiSJbkkgxOzpoSu5WY6mXWnJl9EWEOnTNQCPJRZCM4e45r3XIl+e6J/H/YAkua+UrOiytTcnKNKIUDpxNFQ7u5nr3pj0EZ2Jy0MYZmuBcVm4WqPHowKi1SAa7Zw1Nh9D0AsDmi6m1n+H/MoT1pKId7r+2LUyskEWCEiwgS1D1ka2zBj8haCZhxcTSmdoHLyU7SZ3c9OAa5nasFy0ss1/58FgofiOrzWpEU12U+0Sv1wVlttHO6pGaokD8aRx8aggYsWe0QDbNIbfj+7/Ej3eYKDCJHXjeMr7BqRVS+BuqmpmRLwTSYnPd40MQtWq0urUtPjg6krmwZdLIH/UIg3UVPQEJrBG1A/KpoGS+DkNp9LbYKslu9eZHNwji668KW+U6WloT2kUPvSMH3GeKDVQBy3h2XK10P8YQsr4D81ZPUAUqHiIseICBEOmInxgKHjGopFYucTci9SviJdLbvyz78Px9Vfg8mYb2saxtzYWfSEKUdOdblLrjbc5rYWezty2kaFHF7zwrJEKKi6q2YJcQFGXWDFK09gnBOqT5jijaaygNkxtdJNCBI3BGNDgkFwWN4eD9eP1flayHtpW/poygiz5GMs3NsgKgJoulY96Kjj/34W2YW0VlDIT0Jw4HSdOP1wJ/8V7Gx6bg/v0BHIY4/KuI7ruXuyfkHpgOMdWKo=
+    global:
+        - AWS_ACCESS_KEY_ID=AKIAIELROGTP3V2UJKRA
+        - secure: ExiSJbkkgxOzpoSu5WY6mXWnJl9EWEOnTNQCPJRZCM4e45r3XIl+e6J/H/YAkua+UrOiytTcnKNKIUDpxNFQ7u5nr3pj0EZ2Jy0MYZmuBcVm4WqPHowKi1SAa7Zw1Nh9D0AsDmi6m1n+H/MoT1pKId7r+2LUyskEWCEiwgS1D1ka2zBj8haCZhxcTSmdoHLyU7SZ3c9OAa5nasFy0ss1/58FgofiOrzWpEU12U+0Sv1wVlttHO6pGaokD8aRx8aggYsWe0QDbNIbfj+7/Ej3eYKDCJHXjeMr7BqRVS+BuqmpmRLwTSYnPd40MQtWq0urUtPjg6krmwZdLIH/UIg3UVPQEJrBG1A/KpoGS+DkNp9LbYKslu9eZHNwji668KW+U6WloT2kUPvSMH3GeKDVQBy3h2XK10P8YQsr4D81ZPUAUqHiIseICBEOmInxgKHjGopFYucTci9SviJdLbvyz78Px9Vfg8mYb2saxtzYWfSEKUdOdblLrjbc5rYWezty2kaFHF7zwrJEKKi6q2YJcQFGXWDFK09gnBOqT5jijaaygNkxtdJNCBI3BGNDgkFwWN4eD9eP1flayHtpW/poygiz5GMs3NsgKgJoulY96Kjj/34W2YW0VlDIT0Jw4HSdOP1wJ/8V7Gx6bg/v0BHIY4/KuI7ruXuyfkHpgOMdWKo=

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
         "webpack-bundle-analyzer": "^3.0.2",
         "webpack-cli": "^3.1.1",
         "webpack-dev-server": "^3.1.9",
-        "webpack-manifest-plugin": "^2.0.4",
         "webpack-subresource-integrity": "^1.1.0-rc.6"
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,6 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
     .BundleAnalyzerPlugin;
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const InlineManifestWebpackPlugin = require('inline-manifest-webpack-plugin');
-const ManifestPlugin = require('webpack-manifest-plugin');
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const SriPlugin = require('webpack-subresource-integrity');
 
@@ -60,7 +59,6 @@ module.exports = (env = {}) => {
             new MiniCssExtractPlugin({
                 filename: '[name].[contenthash].css',
             }),
-            new ManifestPlugin(),
             ...(!isTest
                 ? [
                       new HtmlWebpackPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4336,15 +4336,6 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
-fs-extra@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
-  integrity sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -5915,13 +5906,6 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsontoxml@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/jsontoxml/-/jsontoxml-0.0.11.tgz#373ab5b2070be3737a5fb3e32fd1b7b81870caa4"
@@ -6198,11 +6182,6 @@ lodash.tail@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
   integrity sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=
 
-"lodash@>=3.5 <5", lodash@^4.11.1, lodash@^4.17.3:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-  integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
-
 lodash@^3.10.0, lodash@^3.2.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -6212,6 +6191,11 @@ lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5,
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@^4.11.1, lodash@^4.17.3:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+  integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
 
 lodash@~2.4.1:
   version "2.4.2"
@@ -9648,11 +9632,6 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -9987,15 +9966,6 @@ webpack-log@^2.0.0:
   dependencies:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
-
-webpack-manifest-plugin@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz#e4ca2999b09557716b8ba4475fb79fab5986f0cd"
-  integrity sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==
-  dependencies:
-    fs-extra "^7.0.0"
-    lodash ">=3.5 <5"
-    tapable "^1.0.0"
 
 webpack-sources@^1.1.0, webpack-sources@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
I think this will let us merge `sunset-legacy` to `master` and then later move the DNS. Legacy relies on `manifest.json` to load assets outputted by webpack. Leaving the old `manifest.json` in Cloudfront/S3 should allow the legacy app to keep using it to load old assets that are still in the bucket. The new `index.html` will load the new assets from the `sunset-legacy` branch.

Let me know if you see any issues with this. I guess if we have issues we could just quickly switch DNS and suffer a little bit of downtime.