### PR TITLE
MHP-2418: Fix undefined orgPermission when accessing archive_date

### DIFF
--- a/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.component.js
+++ b/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.component.js
@@ -112,7 +112,8 @@ function peopleScreenController(
                     this.org.id,
                 );
 
-                if (orgPermission.archive_date !== null) return 'Archived';
+                if (!orgPermission || orgPermission.archive_date !== null)
+                    return 'Archived';
 
                 return personService.getFollowupStatus(person, this.org.id);
             },


### PR DESCRIPTION
Do you think this is a safe assumption? Not sure why the org permissions aren't loaded.