### PR TITLE
Fix travis build

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,7 @@
 .prettierignore
 coverage
 *.snap
-package.json
 yarn.lock
 README.md
 netlify.toml
-.babelrc
 schema.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
-node_js: '8'
+node_js: '12'
 addons:
     chrome: stable
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8817,17 +8817,10 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minipass@^2.2.1, minipass@^2.3.4:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minipass@^2.6.4:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.8.3.tgz#aa87cf674150a1b3c8e278c5f5937d1d3d02b955"
-  integrity sha512-NcbXxDThFeNW47XHPCCsb6uQdAg7CHy4KNCPKzE0KN2VC0t4E09beCsI5x+3UnB6+AFMnC9jso92SB3KGRpkJQ==
+minipass@^2.2.1, minipass@^2.3.4, minipass@^2.6.4:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.8.5.tgz#072f3c67b1f05fe4703f58a3c38e186c03a17692"
+  integrity sha512-D5+szmZBoOAfbLjOXY4Ve5bWylyTdrUOmbJPgYmgTF5ovCnCFFTY+I16Ccm/UjSNNAekXtIEDvoCDioFzRz18Q==
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"


### PR DESCRIPTION
- Bump travis node version to 12
- Bump minipass to 2.8.5 to fix https://github.com/lovell/sharp/issues/1882#issuecomment-534472345

Our builds have been failing for the last day or so. https://travis-ci.org/CruGlobal/missionhub-web/builds

I merged this to staging which was successful. https://travis-ci.org/CruGlobal/missionhub-web/builds/589195127

The node upgrade wasn't necessary for the fix but figured I'd upgrade it anyways.