### PR TITLE
Small fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
         "@types/react-dom": "^16.9.0",
         "@types/react-redux": "^7.1.5",
         "@types/react-router-dom": "^4.3.5",
-        "@types/styled-components": "^4.1.18",
         "@typescript-eslint/parser": "^2.3.3",
         "angular-mocks": "^1.7.8",
         "apollo-link-schema": "^1.2.4",

--- a/src/testUtils/globalMocks.ts
+++ b/src/testUtils/globalMocks.ts
@@ -15,7 +15,7 @@ export const globalMocks = {
     Float: () => faker.random.number({ precision: 0.01 }),
     Boolean: () => faker.random.boolean(),
     ID: () => nextId(),
-    ISO8601DateTime: () => faker.date.past(10, '2020-01-14').toUTCString(),
+    ISO8601DateTime: () => faker.date.past(10, '2020-01-14').toISOString(),
     ISO8601Date: () =>
         moment(faker.date.past(10, '2020-01-14')).format('YYYY-MM-DD'),
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,14 +2095,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-native@*":
-  version "0.60.9"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.60.9.tgz#89135a6ac9a71a64837e2100dc8dbc7a71b4fe34"
-  integrity sha512-fsceCFV6UQOoQ/DzLS0ya82mZdGmUhMvkkVIq3pjMmxcxR6ENb0noPw6ssE4aVx61J6ukth+MT2PNFgy6eQ9iQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/react" "*"
-
 "@types/react-redux@^7.1.5":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.5.tgz#c7a528d538969250347aa53c52241051cf886bd3"
@@ -2141,15 +2133,6 @@
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
-
-"@types/styled-components@^4.1.18":
-  version "4.1.18"
-  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.1.18.tgz#348804fe5a399ae0a46550afaf030085815ad931"
-  integrity sha512-VrHkgvjbxQXOw0xWSUckusUUZ4y/jqN1u7kF29ngh0oE6uOrlZHleTgqeUqylQqHQIeQ8MxFb50BRHy8ju5DHg==
-  dependencies:
-    "@types/react" "*"
-    "@types/react-native" "*"
-    csstype "^2.2.0"
 
 "@types/testing-library__dom@*":
   version "6.0.0"


### PR DESCRIPTION
A couple random things I've noticed:

1. Dependabot was trying to upgrade styled-components which we aren't using. Jon must have accidentally added it.
2. The format from the API is ISO8601, not a human readable UTC version. This was causing bugs on mobile and I have a fix for that repo in my StepsScreen GraphQL PR.