### PR TITLE
Add support for campus contacts domains

### DIFF
--- a/app/assets/javascripts/angular/components/organizationOverview/organizationOverview.html
+++ b/app/assets/javascripts/angular/components/organizationOverview/organizationOverview.html
@@ -55,7 +55,7 @@
             <div
                 class="tab pivot-white"
                 ng-class="{active: $ctrl.isInsightsTab()}"
-                ng-if="!$ctrl.envService.is('production')"
+                ng-if="!$ctrl.(envService.is('production') && !$ctrl.envService.is('productionCampusContacts'))"
                 ng-click="$ctrl.orgNavOpen = false"
             >
                 <a

--- a/app/assets/javascripts/angular/missionhubApp.config.js
+++ b/app/assets/javascripts/angular/missionhubApp.config.js
@@ -1,6 +1,36 @@
 angular
     .module('missionhubApp')
     .config((envServiceProvider) => {
+        const environmentVars = {
+            development: {
+                apiUrl: 'https://api-stage.missionhub.com/apis/v4',
+                theKeyUrl: 'https://thekey.me/cas',
+                theKeyClientId: '4921314596573158029',
+                facebookAppId: '233292170040365',
+                surveyLinkPrefix: 'http://localhost:8080/s/',
+                googleAnalytics: 'UA-XXXXXX-XX',
+                getMissionHub: 'http://localhost:8080',
+            },
+            staging: {
+                apiUrl: 'https://api-stage.missionhub.com/apis/v4',
+                theKeyUrl: 'https://thekey.me/cas',
+                theKeyClientId: '8138475243408077361',
+                facebookAppId: '233292170040365',
+                surveyLinkPrefix: 'https://stage.mhub.cc/s/',
+                googleAnalytics: 'UA-XXXXXX-XX',
+                getMissionHub: 'https://stage.missionhub.com',
+            },
+            production: {
+                apiUrl: 'https://api.missionhub.com/apis/v4',
+                theKeyUrl: 'https://thekey.me/cas',
+                theKeyClientId: '8480288430352167964',
+                facebookAppId: '233292170040365',
+                surveyLinkPrefix: 'https://mhub.cc/s/',
+                googleAnalytics: 'UA-325725-21',
+                getMissionHub: 'https://get.missionhub.com',
+            },
+        };
+
         envServiceProvider.config({
             domains: {
                 development: ['localhost', 'missionhub.local'],
@@ -11,40 +41,33 @@ angular
                     '*.netlify.com',
                     '*.netlify.app',
                 ],
+                stagingCampusContacts: [
+                    '*.campuscontacts.cru.org',
+                    '*.ccontacts.app',
+                    '*.d11caubtn1mk5o.amplifyapp.com',
+                ],
                 production: [
                     'missionhub.com',
                     'www.missionhub.com',
                     'mhub.cc',
                     'www.mhub.cc',
                 ],
+                productionCampusContacts: [
+                    'campuscontacts.cru.org',
+                    'ccontacts.app',
+                ],
             },
             vars: {
-                development: {
-                    apiUrl: 'https://api-stage.missionhub.com/apis/v4',
-                    theKeyUrl: 'https://thekey.me/cas',
-                    theKeyClientId: '4921314596573158029',
-                    facebookAppId: '233292170040365',
-                    surveyLinkPrefix: 'http://localhost:8080/s/',
-                    googleAnalytics: 'UA-XXXXXX-XX',
-                    getMissionHub: 'http://localhost:8080',
+                ...environmentVars,
+                stagingCampusContacts: {
+                    ...environmentVars.staging,
+                    apiUrl: 'https://campus-contacts-api-stage.cru.org/apis/v4',
+                    surveyLinkPrefix: 'https://stage.ccontacts.app/s/',
                 },
-                staging: {
-                    apiUrl: 'https://api-stage.missionhub.com/apis/v4',
-                    theKeyUrl: 'https://thekey.me/cas',
-                    theKeyClientId: '8138475243408077361',
-                    facebookAppId: '233292170040365',
-                    surveyLinkPrefix: 'https://stage.mhub.cc/s/',
-                    googleAnalytics: 'UA-XXXXXX-XX',
-                    getMissionHub: 'https://stage.missionhub.com',
-                },
-                production: {
-                    apiUrl: 'https://api.missionhub.com/apis/v4',
-                    theKeyUrl: 'https://thekey.me/cas',
-                    theKeyClientId: '8480288430352167964',
-                    facebookAppId: '233292170040365',
-                    surveyLinkPrefix: 'https://mhub.cc/s/',
-                    googleAnalytics: 'UA-325725-21',
-                    getMissionHub: 'https://get.missionhub.com',
+                productionCampusContacts: {
+                    ...environmentVars.production,
+                    apiUrl: 'https://campus-contacts-api.cru.org/apis/v4',
+                    surveyLinkPrefix: 'https://ccontacts.app/s/',
                 },
             },
         });

--- a/app/assets/javascripts/angular/missionhubApp.run.js
+++ b/app/assets/javascripts/angular/missionhubApp.run.js
@@ -30,7 +30,8 @@ angular
 
         analyticsService.init();
 
-        envService.is('production') &&
+        (envService.is('production') ||
+            envService.is('productionCampusContacts')) &&
             $location.absUrl().match(/(www\.)?missionhub\.com\/?$/) &&
             !authenticationService.isTokenValid() &&
             ($window.location.href = envService.read('getMissionHub'));

--- a/app/assets/javascripts/angular/services/analyticsService.js
+++ b/app/assets/javascripts/angular/services/analyticsService.js
@@ -96,9 +96,11 @@ function analyticsService(
     };
 
     const loadAdobeScript = () => {
-        const url = envService.is('production')
-            ? '//assets.adobedtm.com/launch-EN541f7d1d75de45f78e4e3881d6264bae.min.js'
-            : '//assets.adobedtm.com/launch-ENe4ca7f50fed34edd995d7c6294e6b509-development.min.js';
+        const url =
+            envService.is('production') ||
+            envService.is('productionCampusContacts')
+                ? '//assets.adobedtm.com/launch-EN541f7d1d75de45f78e4e3881d6264bae.min.js'
+                : '//assets.adobedtm.com/launch-ENe4ca7f50fed34edd995d7c6294e6b509-development.min.js';
 
         return loadScript(url, 'adobe-analytics');
     };

--- a/index.ejs
+++ b/index.ejs
@@ -13,11 +13,11 @@
         />
 
         <script>
-            (function(i, s, o, g, r, a, m) {
+            (function (i, s, o, g, r, a, m) {
                 i['GoogleAnalyticsObject'] = r;
                 (i[r] =
                     i[r] ||
-                    function() {
+                    function () {
                         (i[r].q = i[r].q || []).push(arguments);
                     }),
                     (i[r].l = 1 * new Date());
@@ -48,10 +48,10 @@
         <script>
             // Disable the help scout beacon if the user is taking a survey
             if (
-                window.location.origin !== 'https://stage.mhub.cc' &&
-                window.location.origin !== 'https://mhub.cc'
+                !window.location.origin.includes('mhub.cc') &&
+                !window.location.origin.includes('ccontacts.app')
             ) {
-                !(function(e, t, n) {
+                !(function (e, t, n) {
                     function a() {
                         var e = t.getElementsByTagName('script')[0],
                             n = t.createElement('script');
@@ -61,7 +61,7 @@
                             e.parentNode.insertBefore(n, e);
                     }
                     if (
-                        ((e.Beacon = n = function(t, n, a) {
+                        ((e.Beacon = n = function (t, n, a) {
                             e.Beacon.readyQueue.push({
                                 method: t,
                                 options: n,
@@ -75,7 +75,7 @@
                     e.attachEvent
                         ? e.attachEvent('onload', a)
                         : e.addEventListener('load', a, !1);
-                })(window, document, window.Beacon || function() {});
+                })(window, document, window.Beacon || function () {});
                 window.Beacon('init', '8e1f984b-c505-4d96-b8cb-58f773b7883c');
             }
         </script>


### PR DESCRIPTION
Here are all the domains I've configured with Amplify: https://console.aws.amazon.com/amplify/home?region=us-east-1&code=d0ca7f22cb2d130ebcc1#/d11caubtn1mk5o/settings/domains

~~I asked Frett to whitelist these domains with The Key but it was late in the day. So The Key sign in won't work till he updates that.~~ He's updated the config. Stage and prod still won't work until this is merged but the Amplify link does.

Facebook sign in for stage and prod will work once thisis merged but since Facebook doesn't support wildcard redirect urls, the deploy previews don't work.