### PR TITLE
Remove extra parenthesis in template

### DIFF
--- a/app/assets/javascripts/angular/components/organizationOverview/organizationOverview.html
+++ b/app/assets/javascripts/angular/components/organizationOverview/organizationOverview.html
@@ -55,7 +55,7 @@
             <div
                 class="tab pivot-white"
                 ng-class="{active: $ctrl.isInsightsTab()}"
-                ng-if="!$ctrl.(envService.is('production') && !$ctrl.envService.is('productionCampusContacts'))"
+                ng-if="!$ctrl.(envService.is('production') && !$ctrl.envService.is('productionCampusContacts')"
                 ng-click="$ctrl.orgNavOpen = false"
             >
                 <a


### PR DESCRIPTION
Angular templates are great at error checking :(

Guess this isn't an issue in prod cuz throwing an error in an `ng-if` is `false`? 🤷‍♂️ It's just hiding the insights tab which we want anyways.