### PR TITLE
Fix survey responses load more

### DIFF
--- a/app/assets/javascripts/angular/components/organizationOverviewSuborgs/organizationOverviewSuborgs.component.js
+++ b/app/assets/javascripts/angular/components/organizationOverviewSuborgs/organizationOverviewSuborgs.component.js
@@ -1,4 +1,5 @@
 import template from './organizationOverviewSuborgs.html';
+import './organizationOverviewSuborgs.scss';
 
 angular.module('missionhubApp').component('organizationOverviewSuborgs', {
     controller: organizationOverviewSuborgsController,

--- a/app/assets/javascripts/angular/components/organizationOverviewSuborgs/organizationOverviewSuborgs.html
+++ b/app/assets/javascripts/angular/components/organizationOverviewSuborgs/organizationOverviewSuborgs.html
@@ -5,7 +5,7 @@
     class="grid-content grid-fixed"
 >
     <div
-        class="suborg row padded"
+        class="suborg row"
         ng-repeat="org in $ctrl.subOrgs | orderBy: 'name' track by org.id"
     >
         <a

--- a/app/assets/javascripts/angular/components/organizationOverviewSuborgs/organizationOverviewSuborgs.scss
+++ b/app/assets/javascripts/angular/components/organizationOverviewSuborgs/organizationOverviewSuborgs.scss
@@ -1,0 +1,5 @@
+organization-overview-suborgs {
+    .suborg {
+        padding: 0 9px;
+    }
+}

--- a/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.html
+++ b/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.html
@@ -232,7 +232,11 @@
                             show-last-survey="$ctrl.surveyId"
                         >
                         </ministry-view-person>
-                        <div ng-if="!$ctrl.loadedAll" class="row message-row">
+                        <div
+                            ng-if="!$ctrl.loadedAll"
+                            class="row message-row"
+                            ng-click="$ctrl.loadPersonPage()"
+                        >
                             {{ 'general.loading_more' | t }}
                         </div>
                     </div>

--- a/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.html
+++ b/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.html
@@ -234,7 +234,7 @@
                         </ministry-view-person>
                         <div
                             ng-if="!$ctrl.loadedAll"
-                            class="row message-row"
+                            class="row message-row loading-more"
                             ng-click="$ctrl.loadPersonPage()"
                         >
                             {{ 'general.loading_more' | t }}

--- a/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.scss
+++ b/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.scss
@@ -129,4 +129,7 @@ people-screen {
     .pointer-disabled:hover {
         cursor: auto;
     }
+    .loading-more:hover {
+        text-decoration: underline;
+    }
 }


### PR DESCRIPTION
I spent most of my afternoon trying to figure this out and I really have no idea what's happening. I feel like it's some AngularJS internal bug that is dependent on how the function gets triggered.

I haven't fixed this but added a workaround of allowing the user to click the "Loading more..." (and also fixed some styling on the suborgs page).

https://github.com/sroze/ngInfiniteScroll/blob/master/src/infinite-scroll.js#L92 calls the `loadPersonPage` function which runs https://github.com/CruGlobal/missionhub-web/blob/77b4af27ab5eacd0722c4b3860fc1ee3685d2740/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.component.js#L216 every single time but the Angular view never updates. I've tried all the normal AngularJS hacks I can think of and can't get anything to work. If I call `loadPersonPage` in a `ng-click` it works great :(

Also it's only a bug if you get to https://localhost:8080/ministries/16233/survey/19237/responses from another page. If you refresh the page while there, it works great :(
